### PR TITLE
Make test cases fail when satysfi does not exist

### DIFF
--- a/__test__/regression.test.js
+++ b/__test__/regression.test.js
@@ -3,6 +3,8 @@ const gm = require('gm');
 const { toMatchImageSnapshot } = require('jest-image-snapshot');
 expect.extend({ toMatchImageSnapshot });
 
+shell.config.fatal = true
+
 shell.cd('__test__');
 
 const compileSatyToImg = (filename) => {
@@ -20,7 +22,7 @@ const compileSatyToImg = (filename) => {
 }
 
 afterAll(() => {
-  shell.rm('**/*.pdf', '**/*.satysfi-aux');
+  shell.rm('-f', '**/*.pdf', '**/*.satysfi-aux');
 })
 
 test('Confirm that satysfi is installed', () => {


### PR DESCRIPTION
By some reason, failure of a process executed with .exec() does not have other processes in the pipe be killed, which makes some test cases diverge.

You can reproduce the problem with running `yarn test` without having `satysfi` in the PATH.