### PR TITLE
Providing new functions to split strings with the delimiters

### DIFF
--- a/__test__/__snapshots__/regression.test.js.snap
+++ b/__test__/__snapshots__/regression.test.js.snap
@@ -10,6 +10,10 @@ exports[`Check compiler outputs 1`] = `
 [32m[debug.log] ==== String ====[0m
 [32m[debug.log] abc[0m
 [32m[debug.log] true[0m
+[32m[debug.log] spam[0m
+[32m[debug.log] ham[0m
+[32m[debug.log] eggs[0m
+[32m[debug.log] [0m
 [32m[debug.log] a[0m
 [32m[debug.log] b[0m
 [32m[debug.log] c[0m

--- a/__test__/satysrc/generic.saty
+++ b/__test__/satysrc/generic.saty
@@ -49,6 +49,7 @@ let () = Debug.log (String.of-int (Ref.get r)) in % 1
 let () = Debug.log `==== String ====` in
 let () = Debug.log (String.concat [`a`; `b`; `c`;]) in
 let () = Debug.log (String.of-bool (String.is-empty `  `)) in % true
+let _ = String.split-by (Char.make `;`) `spam;ham;eggs;` |> List.map Debug.log in
 let _ = String.to-list `abc` |> List.map (fun c -> (c |> String.of-char |> Debug.log)) in
 
 let () = Debug.log `==== Array ====` in

--- a/src/string.satyg
+++ b/src/string.satyg
@@ -82,7 +82,7 @@ end = struct
         (sub 0 len s, Some(sub (len + 1) (maxlen - len - 1) s))
       else
         aux maxlen (len + 1)
-    in aux (string-length s) 0
+    in aux (length s) 0
 
   let-rec split-by d s =
     match split-by-first d s with

--- a/src/string.satyg
+++ b/src/string.satyg
@@ -25,6 +25,9 @@ module String : sig
   val to-list : string -> Char.t list
   val pow : int -> string -> string
   val split : int -> string -> string * string
+  val split-by-first : Char.t -> string -> string * string option
+  val split-by : Char.t -> string -> string list
+  val lines : string -> string list
   val index : Char.t -> string -> int option
   % val byte-length : string -> int
   % val sub-bytes : int -> int -> string -> string
@@ -70,7 +73,24 @@ end = struct
 
   let split i s =
     (sub 0 i s, sub i (length s - i) s)
-  
+
+  let split-by-first d s =
+    let-rec aux maxlen len =
+      if len >= maxlen then
+        (s, None)
+      else if Char.equal (Char.at len s) d then
+        (sub 0 len s, Some(sub (len + 1) (maxlen - len - 1) s))
+      else
+        aux maxlen (len + 1)
+    in aux (string-length s) 0
+
+  let-rec split-by d s =
+    match split-by-first d s with
+    | (head, Some(tail)) -> head :: split-by d tail
+    | (head, None)       -> [head]
+
+  let lines = split-by Char.newline
+
   let index c s =
     let cs = to-list s in
     let-rec aux cs acc = match cs with


### PR DESCRIPTION
This request is to add the three new functions to the module `String`.
They are aiming to split `string`s using various delimiters which are typed as `Char.t`.

* `split-by d s : Char.t -> string -> string list`
    It makes a list of strings by separating `s` at each character that equals to `d`.
* `split-by-first d s : Char.t -> string -> string * string option`
    It makes a pair of string (or nothing) by separating `s` at the first character that equals to `d` appearing while scanning `s` from the left.
    If `s` does not contains `d`, the first of the returned pair will be the entire part of `s` and the second will be `None`.
    Otherwise the first of the returned pair will be the first part of `s` and the second will be the remained part.
* `lines s : string -> string list`
    It is an equivalent of `split-by Char.newline s`.

For every functions, the character used to chop the string won't be contained to the results.

This request also add the tests and the snapshot for these new functions.

Thank you.