### PR TITLE
Install only base package during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           eval $(opam env)
           opam update
           opam pin add --verbose --yes "."
-          satyrographos install
+          satyrographos install -l base
       - name: Run regression tests
         run: |
           export HOME=/root

--- a/Satyristes
+++ b/Satyristes
@@ -6,4 +6,5 @@
     ((packageDir "src")
 	))
   (opam "satysfi-base.opam")
-  (dependencies ((fonts-dejavu ()))))
+  (dependencies ((fonts-dejavu ())
+                 (zrbase ()))))


### PR DESCRIPTION
This PR specifies `base` as the required library of `satyrographos install` subcommand. In addition, this fixes `Satyristes` file which was not updated in #59.