### PR TITLE
Remove the sentence about `zrbase` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,3 @@ If you are intersted in development of this project, please contact us.
 ## License
 
 All files in this repository are licensed under MIT.
-Files under `zrbase` are originally written by Takayuki YATO.


### PR DESCRIPTION
- This sentence was added by https://github.com/nyuichi/satysfi-base/commit/e298f2541d1a07f5af59d81d5a5aa9b4638d76e7
- But now `zrbase` directory has been gone
    - It was separated by this PR 👉 #59 ?
- So I remove this sentence