### PR TITLE
Add dependency on satysfi-dist

### DIFF
--- a/satysfi-base.opam
+++ b/satysfi-base.opam
@@ -19,6 +19,7 @@ bug-reports: "https://github.com/nyuichi/satysfi-base/issues"
 dev-repo: "git+https://github.com/nyuichi/satysfi-base.git"
 depends: [
   "satysfi" {>= "0.0.3" & < "0.0.5"}
+  "satysfi-dist"
   "satyrographos" {>= "0.0.2.3" & < "0.0.3"}
   "satysfi-fonts-dejavu" {>= "2.37"}
   "satysfi-zrbase" {>= "0.4.0"}


### PR DESCRIPTION
As some libraries (e.g., list-ext.satyg) actually depends on the SATySFi standard library, the opam file should have dependency on satysfi-dist.