### PR TITLE
[WIP] Extend 'StringParser.run' for passing initial positions

### DIFF
--- a/src/parser.satyg
+++ b/src/parser.satyg
@@ -286,7 +286,10 @@ end = struct
 end
 
 module StringParser : sig
-  val run : 'a Char.t Parser.t -> string -> 'a ((Char.t parse-error) list) result
+  % [run p ?:init-pos s] runs parser [p] for input [s].
+  % Here, [init-pos] stands for the initial position of the input.
+  % If omitted, the optional argument defaults to [Token.initial-position], i.e., [(|line = 1; column = 0|)].
+  val run : 'a Char.t Parser.t -> token-position?-> string -> 'a ((Char.t parse-error) list) result
   val char : Char.t -> Char.t Char.t Parser.t
   val string : string -> string Char.t Parser.t  % wrapped with `try`
   val satisfy : (Char.t -> bool) -> Char.t Char.t Parser.t
@@ -310,7 +313,7 @@ end = struct
     | (c :: cs) = char c >> aux cs
     in try (aux (String.to-list str))
 
-  let lex-string input =
+  let lex-string init-pos input =
     Stream.unfold (fun (cs, pos) -> (
       match List.uncons cs with
       | None -> Option.none
@@ -321,10 +324,11 @@ end = struct
           let column = if Char.equal c Char.newline then 0 else pos#column + 1 in
           (| line = line; column = column |)
         in Option.some (token, (new-cs, new-pos))
-    )) (String.to-list input, Token.initial-position)
+    )) (String.to-list input, init-pos)
 
-  let run p input =
-    input |> lex-string |> Parser.run p
+  let run p ?:init-pos-opt input =
+    let init-pos = init-pos-opt |> Option.from Token.initial-position in
+    input |> lex-string init-pos |> Parser.run p
 
   let satisfy f =
     Parser.satisfy (fun t -> f (Token.data t)) <&> Token.data


### PR DESCRIPTION
This PR adds an optional argument to `StringParser.run` for passing the initial position of inputs.

```diff
+  val run : 'a Char.t Parser.t -> token-position?-> string -> 'a ((Char.t parse-error) list) result
-  val run : 'a Char.t Parser.t -> string -> 'a ((Char.t parse-error) list) result
```

This will be useful for reporting exact positions where an error occurred during parsing, especially during parsing at the preprocessing stage.