### PR TITLE
Fix 'Parser.run' about accumulated errors

### DIFF
--- a/__test__/__snapshots__/regression.test.js.snap
+++ b/__test__/__snapshots__/regression.test.js.snap
@@ -134,6 +134,7 @@ exports[`Check compiler outputs 1`] = `
 [32m[debug.log] aaa[0m
 [32m[debug.log] 3[0m
 [32m[debug.log] 10[0m
+[32m[debug.log] bar[0m
 [32m[debug.log] ==== Lexer ====[0m
 [32m[debug.log] (| kind = identifier, data = \\"abc\\" |)[0m
 [32m[debug.log] (| kind = whitespace, data = \\" \\" |)[0m

--- a/__test__/satysrc/generic.saty
+++ b/__test__/satysrc/generic.saty
@@ -173,6 +173,20 @@ let () =
     `12/2/2` |> run expr |> Result.map (Fn.compose Debug.log String.of-int) |> Fn.ignore before
     `1+2*4-12/2/2+4` |> run expr |> Result.map (Fn.compose Debug.log String.of-int) |> Fn.ignore in
 
+let () =
+  open Parser in
+  open StringParser in
+  let p =
+        (label `expected 'foo'` (string `foo`))
+    <|> (string `bar`)
+  in
+  `bar` |> run p |> Result.map Debug.log |> Result.map-err (fun errs -> (
+    match errs with
+    | []       -> Debug.log `(something is wrong)`
+    | err :: _ -> Debug.log err#desc
+  )) |> Fn.ignore
+in
+
 let () = Debug.log `==== Lexer ====` in
 let rules = [
   (| kind = `identifier`; regexp = seq alpha (many (alt alpha (alt digit (char (Char.make `-`))))) |);

--- a/src/parser.satyg
+++ b/src/parser.satyg
@@ -119,9 +119,9 @@ end = struct
   let run p s =
     let initial-state = (| input = s |) in
     match p initial-state with
-    | (Some (_, a), _, _) ->
+    | (Some (_, a), _, []) ->
       Result.ok a
-    | (None, _, es) ->
+    | (_, _, es) ->
       Result.err es
 
   let delay t =

--- a/src/parser.satyg
+++ b/src/parser.satyg
@@ -176,8 +176,9 @@ end = struct
   let alt p1 p2 s =
     match p1 s with
     | (None, Virgin, e1) ->
-      let (o, c, e2) = p2 s in
-      (o, c, List.append e2 e1)
+      (match p2 s with
+      | (None, c, e2) -> (Option.none, c, List.append e2 e1)
+      | r -> r)
     | r -> r
 
   let (<|>) = alt

--- a/src/parser.satyg
+++ b/src/parser.satyg
@@ -119,9 +119,9 @@ end = struct
   let run p s =
     let initial-state = (| input = s |) in
     match p initial-state with
-    | (Some (_, a), _, []) ->
+    | (Some (_, a), _, _) ->
       Result.ok a
-    | (_, _, es) ->
+    | (None, _, es) ->
       Result.err es
 
   let delay t =


### PR DESCRIPTION
This PR attempts to fix `Parser.run` about error handling. The current implementation of `Parser.run` seems to reject valid inputs when `Parser.label` is used; indeed, the following test is expected to show `bar` but shows `expected 'foo'`:

```
let () =
  open Parser in
  open StringParser in
  let p =
        (label `expected 'foo'` (string `foo`))
    <|> (string `bar`)
  in
  `bar` |> run p |> Result.map Debug.log |> Result.map-err (fun errs -> (
    match errs with
    | []       -> Debug.log `(something is wrong)`
    | err :: _ -> Debug.log err#desc
  )) |> Fn.ignore
in
```

Or, is such a behavior intended? I will appreciate any comments or suggestions.