### PR TITLE
Add `Pager.to-size` api and update SATySFi's version

### DIFF
--- a/satysfi-base.opam
+++ b/satysfi-base.opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/nyuichi/satysfi-base"
 bug-reports: "https://github.com/nyuichi/satysfi-base/issues"
 dev-repo: "git+https://github.com/nyuichi/satysfi-base.git"
 depends: [
-  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satysfi" {>= "0.0.5" & < "0.0.7"}
   "satysfi-dist"
   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
   "satysfi-fonts-dejavu" {>= "2.37"}

--- a/src/pager.satyh
+++ b/src/pager.satyh
@@ -48,8 +48,23 @@ module Page : sig
   val us-letter : page
   val us-legal : page
   val custom : length -> length -> page
+  val to-size : page -> (length * length)
 end = struct
   let custom l1 l2 = UserDefinedPaper(l1,l2)
+
+  % values are from https://github.com/johnwhitington/camlpdf/blob/fd56554adb16ad03f84ad70a721e01a11092a836/pdfpaper.ml
+  let to-size pg =
+    match pg with
+    | A0Paper                -> (841mm,1189mm)
+    | A1Paper                -> (594mm, 841mm)
+    | A2Paper                -> (420mm, 594mm)
+    | A3Paper                -> (297mm, 420mm)
+    | A4Paper                -> (210mm, 297mm)
+    | A5Paper                -> (148mm, 210mm)
+    | USLetter               -> (8.5inch, 11inch)
+    | USLegal                -> (8.5inch, 14inch)
+    | UserDefinedPaper(w, h) -> (w, h)
+
   let a0 = A0Paper
   let a1 = A1Paper
   let a2 = A2Paper


### PR DESCRIPTION
There is no way to get size of `paper`, so I added this new API.