### PR TITLE
Kill dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "20:00"
-  open-pull-requests-limit: 10


### PR DESCRIPTION
This PR removes `.github/dependabot.yml` to stop annoying PRs from dependabot. This won't be a serious issue given that JS dependency is being removed as part of #285.